### PR TITLE
Fix column_order update

### DIFF
--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -132,7 +132,7 @@ class CapAnnData:
 
                 for col in entity.columns:
                     self._write_elem_lzf(f"{key}/{col}", entity[col].values)
-                self._file[key].attrs['column-order'] = entity.column_order
+                self._file[key].attrs['column-order'] = entity.column_order.tolist()
 
         if "uns" in fields:
             for key in self.uns.keys():

--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -97,6 +97,10 @@ class CapAnnData:
 
             for col in cols_to_read:
                 df[col] = read_elem(h5_group[col])
+        if df.column_order.dtype != object:
+            # empty DataFrame will have column_order as float64
+            # which leads to failure in overwrite method
+            df.column_order = df.column_order.astype(object)
         return df
 
     @staticmethod

--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -132,7 +132,7 @@ class CapAnnData:
 
                 for col in entity.columns:
                     self._write_elem_lzf(f"{key}/{col}", entity[col].values)
-                self._file[key].attrs['column-order'] = entity.column_order.tolist()
+                self._file[key].attrs['column-order'] = entity.column_order
 
         if "uns" in fields:
             for key in self.uns.keys():

--- a/test/test_cap_anndata.py
+++ b/test/test_cap_anndata.py
@@ -289,3 +289,22 @@ def test_modify_uns():
     assert new_name in adata.uns.keys()
     assert adata.uns['field_to_expand']["key1"] == d_to_exp
     assert adata.uns['field_to_modify'] == v_to_mod
+
+
+def test_empty_obs_override():
+    """
+    especially for solving the issue:
+    https://github.com/cellannotation/cap-anndata/pull/5
+    """
+    adata = get_base_anndata()
+    temp_folder = tempfile.mkdtemp()
+    file_path = os.path.join(temp_folder, "test_modify_uns.h5ad")
+    adata.write_h5ad(file_path)
+
+    with h5py.File(file_path, 'r+') as f:
+        cap_adata = CapAnnData(f)
+        cap_adata.read_obs()
+
+        cap_adata.obs["cell_type_1"] = pd.Series(data=np.nan, index=cap_adata.obs.index, dtype="category")
+        cap_adata.obs["cell_type_new"] = pd.Series(data=np.nan, index=cap_adata.obs.index, dtype="category")
+        cap_adata.overwrite(fields=["obs"])


### PR DESCRIPTION
Error during override of cap_adata.obs:

```
../anndata_deps/pypi__cap_anndata/cap_anndata/cap_anndata.py:135: in overwrite
    self._file[key].attrs['column-order'] = entity.column_order
h5py/_objects.pyx:54: in h5py._objects.with_phil.wrapper
    ???
h5py/_objects.pyx:55: in h5py._objects.with_phil.wrapper
    ???
../anndata_deps/pypi__h5py/h5py/_hl/attrs.py:104: in __setitem__
    self.create(name, data=value)
../anndata_deps/pypi__h5py/h5py/_hl/attrs.py:182: in create
    htype = h5t.py_create(original_dtype, logical=True)
h5py/h5t.pyx:1658: in h5py.h5t.py_create
    ???
h5py/h5t.pyx:1682: in h5py.h5t.py_create
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   TypeError: No conversion path for dtype: dtype('<U41')
```