### PR TITLE
String representation of CapAnnData

### DIFF
--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -305,8 +305,10 @@ class CapAnnData(BaseLayerMatrixAndDf):
                     if attr is not None:
                         in_memory = set(attr.keys())
                 keys = list(self._file[field].keys())
+                keys = [k for k in keys if k != '_index']
                 keys = [(k if k not in in_memory else f'{k}*') for k in keys]
-                s += f"\n{indent}{field}: {keys}"
+                keys_str = str(keys).replace("*'", "'*")
+                s += f"\n{indent}{field}: {keys_str}"
         s += f"\nNote: fields marked with * are in-memory objects."
         return s
 

--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -294,6 +294,7 @@ class CapAnnData(BaseLayerMatrixAndDf):
     def create_repr(self) -> str:
         indent = " " * 4
         s = f"CapAnnData object"
+        s += f"\n{indent}File: {self._file}"
         s += f"\n{indent}X shape: {self.shape}"
         s += f"\n{indent}Has raw X: {self.raw is not None}"
         for field in ["obs", "obsm", "var", "uns", "layers"]:

--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -290,3 +290,20 @@ class CapAnnData(BaseLayerMatrixAndDf):
 
     def var_keys(self) -> List[str]:
         return self.var.column_order.tolist()
+
+    def create_repr(self) -> str:
+        indent = " " * 4
+        s = f"CapAnnData object"
+        s += f"\n{indent}X shape: {self.shape}"
+        s += f"\n{indent}Has raw X: {self.raw is not None}"
+        for field in ["obs", "obsm", "var", "uns", "layers"]:
+            if field in self._file:
+                keys = list(self._file[field].keys())
+                s += f"\n{indent}{field}: {keys}"
+        return s
+
+    def __repr__(self) -> str:
+        return self.create_repr()
+
+    def __str__(self) -> str:
+        return self.create_repr()

--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -299,8 +299,15 @@ class CapAnnData(BaseLayerMatrixAndDf):
         s += f"\n{indent}Has raw X: {self.raw is not None}"
         for field in ["obs", "obsm", "var", "uns", "layers"]:
             if field in self._file:
+                in_memory = set()
+                if field in ["obs", "var", "uns"]:
+                    attr = getattr(self, field)
+                    if attr is not None:
+                        in_memory = set(attr.keys())
                 keys = list(self._file[field].keys())
+                keys = [(k if k not in in_memory else f'{k}*') for k in keys]
                 s += f"\n{indent}{field}: {keys}"
+        s += f"\nNote: fields marked with * are in-memory objects."
         return s
 
     def __repr__(self) -> str:

--- a/cap_anndata/cap_anndata.py
+++ b/cap_anndata/cap_anndata.py
@@ -309,7 +309,7 @@ class CapAnnData(BaseLayerMatrixAndDf):
                 keys = [(k if k not in in_memory else f'{k}*') for k in keys]
                 keys_str = str(keys).replace("*'", "'*")
                 s += f"\n{indent}{field}: {keys_str}"
-        s += f"\nNote: fields marked with * are in-memory objects."
+        s += f"\n{indent}Note: fields marked with * are in-memory objects."
         return s
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Simple `__repr__` and `__str__` added.

Fixes https://github.com/cellannotation/cap-anndata/issues/19