### PR TITLE
Remove pandas bool_t usage

### DIFF
--- a/cap_anndata/backed_df.py
+++ b/cap_anndata/backed_df.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import numpy as np
-from typing import List, Any, Union
-
-from pandas.core.generic import bool_t
+from typing import List, Any, Union, Optional
 
 try:
     from typing import Self  # Python 3.11+
@@ -79,7 +77,7 @@ class CapAnnDataDF(pd.DataFrame):
         df = self.from_df(result, column_order=column_order)
         return df
 
-    def copy(self, deep: Union[bool_t, None] = True) -> Self:
+    def copy(self, deep: Optional[bool] = True) -> Self:
         column_order = self.column_order_array()
         df = self.from_df(super().copy(deep=deep), column_order=column_order)
         return df


### PR DESCRIPTION
```
/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/cap_anndata/backed_df.py:5: in <module>
    from pandas.core.generic import bool_t
E   ImportError: cannot import name 'bool_t' from 'pandas.core.generic' (/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/pandas/core/generic.py)
```